### PR TITLE
Problem: Alert for not using preferred source is not triggered

### DIFF
--- a/install.xml
+++ b/install.xml
@@ -13,8 +13,12 @@ Installation model
     <item type = "systemd-tmpfiles" />
     <item path = "/var/lib/fty/fty-alert-flexible/rules" name = "../rules/sts-voltage.rule" />
     <item path = "/var/lib/fty/fty-alert-flexible/rules" name = "../rules/sts-frequency.rule" />
+    <item path = "/var/lib/fty/fty-alert-flexible/rules" name = "../rules/sts-preferred-source.rule" />
+    
     <item path = "/usr/share/fty-alert-flexible/rules" name = "../rules/sts-voltage.rule" />
     <item path = "/usr/share/fty-alert-flexible/rules" name = "../rules/sts-frequency.rule" />
+    <item path = "/usr/share/fty-alert-flexible/rules" name = "../rules/sts-preferred-source.rule" />
     <item path = "/usr/share/fty-alert-flexible/rules" name = "../rules/load.rule" />
     <item path = "/usr/share/fty-alert-flexible/rules" name = "../rules/ups.rule" />
+    <item path = "/usr/share/fty-alert-flexible/rules" name = "../rules/threshold.rule" />
 </install>

--- a/rules/sts-preferred-source.rule
+++ b/rules/sts-preferred-source.rule
@@ -1,0 +1,17 @@
+{
+    "name"          : "sts-preferred-source",
+    "description"   : "STS/ATS preferred source alert",
+    "metrics"       : ["input.source", "input.source.preferred"],
+    "types"         : ["sts"],
+    "results"       :  {
+        "high_warning"  : { "action" : ["EMAIL"] }
+    },
+    "evaluation"    : "
+         function main(input, preferred)
+             if input == preferred then
+                 return OK, 'ATS ' .. NAME .. ' is running from preferred input.'
+             end
+             return WARNING, 'ATS ' .. NAME .. ' is running from input ' .. input .. ' (preferred is ' .. preferred .. ')!'
+         end
+    "
+}


### PR DESCRIPTION
Solution: Add rule for flexible alert to evaluate it

Signed-off-by: Tomas Halman <TomasHalman@eaton.com>