### PR TITLE
Problem: Variables are not encoded in rule_json output

### DIFF
--- a/rules/threshold.rule
+++ b/rules/threshold.rule
@@ -31,7 +31,7 @@
                 if (humidity > high_warning) then
                     return HIGH_WARNING, 'Humidity in '..NAME..' is high ('..humidity..'%)'
                 end
-                return OK, "Humidity is within normal limits."
+                return OK, 'Humidity is within normal limits.'
             end
     "
 }

--- a/src/rule.c
+++ b/src/rule.c
@@ -542,6 +542,30 @@ char * rule_json (rule_t *self)
         s_string_append (&json, &jsonsize, "},\n");
     }
     {
+        //variables
+        if (zhashx_size (self->variables)) {
+            s_string_append (&json, &jsonsize, "\"variables\": {\n");
+            char *item = (char *)zhashx_first (self->variables);
+            bool first = true;
+            while (item) {
+                if (first) {
+                    first = false;
+                } else {
+                    s_string_append (&json, &jsonsize, ",\n");
+                }
+                char *key = vsjson_encode_string((char *)zhashx_cursor (self->variables));
+                char *value = vsjson_encode_string (item);
+                s_string_append (&json, &jsonsize, key);
+                s_string_append (&json, &jsonsize, ":");
+                s_string_append (&json, &jsonsize, value);                
+                zstr_free (&key);
+                zstr_free (&value);
+                item = (char *) zhashx_next (self->variables);
+            }
+            s_string_append (&json, &jsonsize, "},\n");
+        }
+    }
+    {
         //json evaluation
         char *eval = vsjson_encode_string (self->evaluation);
         s_string_append (&json, &jsonsize, "\"evaluation\":");
@@ -621,7 +645,6 @@ rule_test (bool verbose)
         rule_t *self = rule_new ();
         assert (self);
         rule_load (self, "./rules/threshold.rule");
-
         //  prepare expected 'variables' hash 
         zhashx_t *expected = zhashx_new ();
         assert (expected);


### PR DESCRIPTION
Solution: Add variables into json,
also threshold rule syntax error fixed.

Signed-off-by: Tomas Halman <TomasHalman@eaton.com>