### PR TITLE
Problem: We don't want global rules now

### DIFF
--- a/install.xml
+++ b/install.xml
@@ -11,9 +11,6 @@ Installation model
 
 <install>
     <item type = "systemd-tmpfiles" />
-    <item path = "/var/lib/fty/fty-alert-flexible/rules" name = "../rules/sts-voltage.rule" />
-    <item path = "/var/lib/fty/fty-alert-flexible/rules" name = "../rules/sts-frequency.rule" />
-    <item path = "/var/lib/fty/fty-alert-flexible/rules" name = "../rules/sts-preferred-source.rule" />
     
     <item path = "/usr/share/fty-alert-flexible/rules" name = "../rules/sts-voltage.rule" />
     <item path = "/usr/share/fty-alert-flexible/rules" name = "../rules/sts-frequency.rule" />


### PR DESCRIPTION
Solution: Remove them ftom working dir, keep them in examples

Signed-off-by: Tomas Halman <TomasHalman@eaton.com>