### PR TITLE
Change the action field of alert messages to zlist

### DIFF
--- a/src/flexible_alert.c
+++ b/src/flexible_alert.c
@@ -156,7 +156,7 @@ flexible_alert_load_rules (flexible_alert_t *self, const char *path)
 }
 
 void
-flexible_alert_send_alert (flexible_alert_t *self, const char *rulename, const char *actions, const char *asset, int result, const char *message, int ttl)
+flexible_alert_send_alert (flexible_alert_t *self, const char *rulename, zlist_t *actions, const char *asset, int result, const char *message, int ttl)
 {
     char *severity = "OK";
     if (result == -1 || result == 1) severity = "WARNING";
@@ -287,7 +287,7 @@ flexible_alert_handle_metric (flexible_alert_t *self, fty_proto_t **ftymsg_p)
             flexible_alert_send_alert (
                 self,
                 quantity,
-                "",
+                NULL,
                 fty_proto_name (ftymsg),
                 ivalue,
                 description,

--- a/src/rule.h
+++ b/src/rule.h
@@ -88,7 +88,7 @@ FTY_ALERT_FLEXIBLE_PRIVATE bool
     rule_type_exists (rule_t *self, const char *type);
 
 //  Get rule actions
-FTY_ALERT_FLEXIBLE_PRIVATE const char *
+FTY_ALERT_FLEXIBLE_PRIVATE zlist_t *
     rule_result_actions (rule_t *self, int result);
 
 //  Get global variables


### PR DESCRIPTION
To do this, we change the internal representation from a
"/"-concatenated string to zlist. As a bonus, this simplifies the json
generation a bit.

Signed-off-by: Michal Marek <MichalMarek1@eaton.com>