### PR TITLE
Properly implement the new rule actions format

### DIFF
--- a/src/rule.c
+++ b/src/rule.c
@@ -200,7 +200,7 @@ rule_json_callback (const char *locator, const char *value, void *data)
             zstr_free (&self->parser.act_mode);
             return 0;
         }
-        char *key = zmalloc(slash - start + 1);
+        char *key = (char *)zmalloc(slash - start + 1);
         memcpy(key, start, slash - start);
         if (is_email) {
             rule_add_result_action (self, key, self->parser.action);

--- a/src/selftest-ro/rules/sts-frequency.rule
+++ b/src/selftest-ro/rules/sts-frequency.rule
@@ -4,8 +4,8 @@
     "metrics"       : ["status.input.1.frequency", "status.input.2.frequency"],
     "types"         : ["sts"],
     "results"       :  {
-        "high_critical"  : { "action" : ["EMAIL", "SMS"] },
-        "high_warning"  : { "action" : ["EMAIL"] }
+        "high_critical"  : { "action" : [{"action": "EMAIL"}, {"action": "SMS"}] },
+        "high_warning"  : { "action" : [{"action": "EMAIL"}] }
     },
     "evaluation"    : "
          function main(i1, i2)

--- a/src/selftest-ro/rules/sts-preferred-source.rule
+++ b/src/selftest-ro/rules/sts-preferred-source.rule
@@ -4,7 +4,7 @@
     "metrics"       : ["input.source", "input.source.preferred"],
     "types"         : ["sts"],
     "results"       :  {
-        "high_warning"  : { "action" : ["EMAIL"] }
+        "high_warning"  : { "action" : [{"action": "EMAIL"}] }
     },
     "evaluation"    : "
          function main(input, preferred)

--- a/src/selftest-ro/rules/sts-voltage.rule
+++ b/src/selftest-ro/rules/sts-voltage.rule
@@ -4,8 +4,8 @@
     "metrics"       : ["status.input.1.voltage", "status.input.2.voltage"],
     "types"         : ["sts"],
     "results"       :  {
-        "high_critical"  : { "action" : ["EMAIL", "SMS"] },
-        "high_warning"  : { "action" : ["EMAIL"] }
+        "high_critical"  : { "action" : [{"action": "EMAIL"}, {"action": "SMS"}] },
+        "high_warning"  : { "action" : [{"action": "EMAIL"}] }
     },
     "evaluation"    : "
          function main(i1, i2)

--- a/src/selftest-ro/rules/test.json
+++ b/src/selftest-ro/rules/test.json
@@ -1,0 +1,13 @@
+{
+"name":"test",
+"description":"this is a test rule",
+"logical_asset":"",
+"metrics":["load.default"],
+"assets":["UPS1"],
+"models":[],
+"groups":[],
+"results": {
+"low_critical": {"action": [{"action": "SMS"}, {"action": "EMAIL"}, {"action": "GPO_INTERACTION", "asset": "gpo-42", "mode": "close"}]},
+"high_critical": {"action": [{"action": "EMAIL"}, {"action": "SMS"}, {"action": "GPO_INTERACTION", "asset": "gpo-42", "mode": "open"}]}},
+"evaluation":"\n         function main(load)\n             if load > 90 then\n                 return HIGH_CRITICAL, NAME .. ' is overloaded (' .. load .. '%);\n             end\n             if load > 70 then\n                 return HIGH_WARNING, NAME .. ' is overloaded (' .. load .. '%);\n             end\n             return OK, 'Load on ' .. NAME ..  ' is within limit (' .. load .. '%)';\n         end\n    "
+}

--- a/src/selftest-ro/rules/test.rule
+++ b/src/selftest-ro/rules/test.rule
@@ -1,14 +1,21 @@
 { "flexible":
 {
-    "name"          : "load",
-    "description"   : "Device load",
+    "name"          : "test",
+    "description"   : "this is a test rule",
     "metrics"       : ["load.default"],
     "assets"        : ["UPS1"],
     "groups"        : [ ],
     "models"        : [ ],
     "results"       :  {
-        "high_critical"  : { "action" : [{"action": "EMAIL"}, {"action": "SMS"}] },
-        "high_warning"  : { "action" : [ ] }
+        "high_critical"  : { "action" : [
+            {"action": "EMAIL"},
+            {"action": "SMS"},
+            {"action": "GPO_INTERACTION", "asset": "gpo-42", "mode": "open"}] },
+        "high_warning"  : { "action" : [ ] },
+        "low_critical": { "action" : [
+            {"action": "SMS"},
+            {"action": "EMAIL"},
+            {"asset": "gpo-42", "action": "GPO_INTERACTION", "mode": "close"}] }
     },
     "evaluation"    : "
          function main(load)

--- a/src/selftest-ro/rules/threshold.rule
+++ b/src/selftest-ro/rules/threshold.rule
@@ -6,10 +6,10 @@
     "models"        : [ ],
     "groups"        : ["all-racks"],
     "results"       :  {
-        "low_critical"  : { "action" : ["EMAIL", "SMS"] },
-        "low_warning"   : { "action" : ["EMAIL"] },
-        "high_critical" : { "action" : ["EMAIL", "SMS" ] },
-        "high_warning"  : { "action" : ["EMAIL" ] }
+        "low_critical"  : { "action" : [{"action": "EMAIL"}, {"action": "SMS"}] },
+        "low_warning"   : { "action" : [{"action": "EMAIL"}] },
+        "high_critical" : { "action" : [{"action": "EMAIL"}, {"action": "SMS"} ] },
+        "high_warning"  : { "action" : [{"action": "EMAIL"} ] }
     },
     "variables" : {
         "low_critical"  : "5",

--- a/src/selftest-ro/rules/ups.rule
+++ b/src/selftest-ro/rules/ups.rule
@@ -6,8 +6,8 @@
     "models"        : [ ],
     "groups"        : ["all-upses"],
     "results"       :  {
-        "high_critical"  : { "action" : ["EMAIL","SMS"] },
-        "high_warning"  : { "action" : ["EMAIL"] }
+        "high_critical"  : { "action" : [{"action": "EMAIL"}, {"action": "SMS"}] },
+        "high_warning"  : { "action" : [{"action": "EMAIL"}] }
     },
     "evaluation"    : "
          function has_bit(x,bit)

--- a/src/vsjson.c
+++ b/src/vsjson.c
@@ -491,9 +491,16 @@ char *vsjson_decode_string (const char *string)
 
 char *vsjson_encode_string (const char *string)
 {
+    if (!string)
+        return NULL;
+    return vsjson_encode_nstring(string, strlen(string));
+}
+
+char *vsjson_encode_nstring (const char *string, size_t len)
+{
     if (!string) return NULL;
 
-    int capacity = strlen (string) + 15;
+    int capacity = len + 15;
     int index = 1;
     const char *p = string;
 
@@ -501,7 +508,7 @@ char *vsjson_encode_string (const char *string)
     if (!encoded) return NULL;
     memset (encoded, 0, capacity);
     encoded[0] = '"';
-    while (*p) {
+    while (*p && p - string < len) {
         switch (*p) {
         case '"':
         case '\\':
@@ -536,7 +543,7 @@ char *vsjson_encode_string (const char *string)
         }
         p++;
         if (capacity - index < 10) {
-            int add = strlen (p) + 15;
+            int add = len - (p - string) + 15;
             char *ne = (char *) realloc (encoded, capacity + add);
             if (ne) {
                 encoded = ne;

--- a/src/vsjson.h
+++ b/src/vsjson.h
@@ -17,6 +17,7 @@ extern "C" {
 
 #define VSJSON_SEPARATOR '/'
 #include <stdbool.h>
+#include <stddef.h>
 
 //  Opaque class structures to allow forward references
 #ifndef VSJSON_T_DEFINED
@@ -58,6 +59,8 @@ int vsjson_parse (const char *json, vsjson_callback_t *func, void *data, bool ca
 char *vsjson_decode_string (const char *string);
 
 char *vsjson_encode_string (const char *string);
+
+char *vsjson_encode_nstring (const char *string, size_t len);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Change the parser and serializer to properly read and write the new
format of actions (array of objects instead of array of values). Change
the rule templates and add a stricter unit test for the parser.

Signed-off-by: Michal Marek <MichalMarek1@eaton.com>