### PR TITLE
Do not let fty-alert-engine overwrite configured actions

### DIFF
--- a/src/rule.c
+++ b/src/rule.c
@@ -419,6 +419,17 @@ int rule_load (rule_t *self, const char *path)
 }
 
 //  --------------------------------------------------------------------------
+// Update new_rule with configured actions of old_rule
+void rule_merge (rule_t *old_rule, rule_t *new_rule)
+{
+    zhash_destroy (&new_rule->result_actions);
+    // XXX: We invalidate the old rule here, because we know it's going to
+    // be destroyed. The proper fix is to use zhashx and duplicate the hash.
+    new_rule->result_actions = old_rule->result_actions;
+    old_rule->result_actions = NULL;
+}
+
+//  --------------------------------------------------------------------------
 //  Save json rule to file
 
 int rule_save (rule_t *self, const char *path)

--- a/src/rule.h
+++ b/src/rule.h
@@ -100,6 +100,10 @@ FTY_ALERT_FLEXIBLE_PRIVATE zhashx_t *
 FTY_ALERT_FLEXIBLE_PRIVATE int
     rule_load (rule_t *self, const char *path);
 
+// Update new_rule with configured actions of old_rule
+FTY_ALERT_FLEXIBLE_PRIVATE void
+    rule_merge (rule_t *old_rule, rule_t *new_rule);
+
 //  Save json rule to file
 FTY_ALERT_FLEXIBLE_PRIVATE int
     rule_save (rule_t *self, const char *path);


### PR DESCRIPTION
fty-alert-egine does not know about configured actions. If we receive a
rule from this actor and this is an update of an existing rule, use the
already configured actions and not the fty-alert-engine template
defaults.

Note: The implementation is a hack to get 1.3 out.