### PR TITLE
Problem: he subcribes more metrics than he really needs

### DIFF
--- a/src/fty-alert-flexible.cfg.in
+++ b/src/fty-alert-flexible.cfg.in
@@ -8,5 +8,5 @@ server
 
 malamute
     endpoint = ipc://@/malamute                     # Malamute endpoint
-    metrics_pattern = .*                            # METRICS consumer pattern
+    metrics_pattern = .*@gpiosensor-.*|.*@sts-.*    # METRICS consumer pattern
  


### PR DESCRIPTION
Solution: reduce subscription pattern to only  sts and gpiosensor metrics.
Signed-off-by: Gerald Guillaume <geraldguillaume@eaton.com>