### PR TITLE
Problem: rules generated by 1.2.0 are unusable after upgrade

### DIFF
--- a/50-fty-alert-flexible-import-into-1.3.0.sh
+++ b/50-fty-alert-flexible-import-into-1.3.0.sh
@@ -52,6 +52,9 @@ if [ "`ls -1 "$GENERATED_RULES_DIR"/*.rule | wc -l`" = 0 ] ; then
 fi
 
 for F in "$GENERATED_RULES_DIR"/*.rule ; do
+    [ -s "$F" ] || { echo "SKIP FILE: $F : is empty or missing" ; continue; }
+    [ -s "$F.bak-import-pre-1.3.0" ] && { echo "SKIP FILE: $F : was already processed earlier" ; continue; }
+
     cp -f "$F" "$F.bak-import-pre-1.3.0" \
     || die "FAILED to copy '$F' into backup '$F.bak-import-pre-1.3.0'"
 

--- a/50-fty-alert-flexible-import-into-1.3.0.sh
+++ b/50-fty-alert-flexible-import-into-1.3.0.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+
+#
+#   Copyright (c) 2018 Eaton
+#
+#   This file is part of the Eaton 42ity project.
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program; if not, write to the Free Software Foundation, Inc.,
+#   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+#! \file    50-fty-alert-flexible-import-into-1.3.0.sh
+#  \brief   Convert fty-alert-flexible configs from format used in release
+#           IPM_Infra-1.2.0 into the next (current) version 1.3.0
+#  \author  Jiri Kukacka <JiriKukacka@Eaton.com>
+#  \author  Michal Marek <MichalMarek1@Eaton.com>
+#  \author  Arnaud Quette <ArnaudQuette@Eaton.com>
+#  \author  Jim Klimov <EvgenyKlimov@Eaton.com>
+#
+# Note: If format changes again, follow up by a similar scriptlet named
+# with the corresponding release version, so it is alphabetically later.
+# Remember that ipc-meta-setup scriptlets generally run once in a lifetime.
+
+### The static rules/templates come with R/O OS image and should not
+### be changed - or they would overlay any subsequent distributed files
+#STATIC_RULES_DIR="/usr/share/fty-alert-flexible/rules"
+GENERATED_RULES_DIR="/var/lib/fty/fty-alert-flexible/rules"
+
+die() {
+    echo "FATAL: $*" >&2
+    exit 1
+}
+
+skip() {
+    echo "SKIP: $*" >&2
+    exit 0
+}
+
+[ -d "$GENERATED_RULES_DIR" -a -w "$GENERATED_RULES_DIR" ] || die "Can not manipulate $GENERATED_RULES_DIR directory"
+if [ "`ls -1 "$GENERATED_RULES_DIR"/*.rule | wc -l`" = 0 ] ; then
+    skip "This script does not apply on this deployment: no local rules were generated yet"
+fi
+
+for F in "$GENERATED_RULES_DIR"/*.rule ; do
+    cp -f "$F" "$F.bak-import-pre-1.3.0" \
+    || die "FAILED to copy '$F' into backup '$F.bak-import-pre-1.3.0'"
+
+    sed -r \
+        -e 's/"action" *: *\[ *"([^"]*)" *\]/"action": \[\{"action": "\1"\}\]/' \
+        -e 's/"action" *: *\[ *"([^"]*)", *"([^"]*)" *\]/"action": \[\{"action": "\1"\}, {"action": "\2"}\]/' \
+        < "$F.bak-import-pre-1.3.0" > "$F" \
+    || die "FAILED to convert '$F' from 1.2.0 format into 1.3.0"
+done

--- a/50-fty-alert-flexible-import-into-1.3.0.sh
+++ b/50-fty-alert-flexible-import-into-1.3.0.sh
@@ -36,6 +36,9 @@
 #STATIC_RULES_DIR="/usr/share/fty-alert-flexible/rules"
 GENERATED_RULES_DIR="/var/lib/fty/fty-alert-flexible/rules"
 
+### Extension for the backup files made by this format-version bumper
+BACKUPEXT="bak-import-pre-1.3.0"
+
 die() {
     echo "FATAL: $*" >&2
     exit 1
@@ -53,14 +56,15 @@ fi
 
 for F in "$GENERATED_RULES_DIR"/*.rule ; do
     [ -s "$F" ] || { echo "SKIP FILE: $F : is empty or missing" ; continue; }
-    [ -s "$F.bak-import-pre-1.3.0" ] && { echo "SKIP FILE: $F : was already processed earlier" ; continue; }
+    [ -s "$F.$BACKUPEXT" ] && { echo "SKIP FILE: $F : was already processed earlier" ; continue; }
 
-    cp -f "$F" "$F.bak-import-pre-1.3.0" \
-    || die "FAILED to copy '$F' into backup '$F.bak-import-pre-1.3.0'"
+    cp -f "$F" "$F.$BACKUPEXT" \
+    || die "FAILED to copy '$F' into backup '$F.$BACKUPEXT'"
+
 
     sed -r \
         -e 's/"action" *: *\[ *"([^"]*)" *\]/"action": \[\{"action": "\1"\}\]/' \
         -e 's/"action" *: *\[ *"([^"]*)", *"([^"]*)" *\]/"action": \[\{"action": "\1"\}, {"action": "\2"}\]/' \
-        < "$F.bak-import-pre-1.3.0" > "$F" \
+        < "$F.$BACKUPEXT" > "$F" \
     || die "FAILED to convert '$F' from 1.2.0 format into 1.3.0"
 done

--- a/50-fty-alert-flexible-import-into-1.3.0.sh
+++ b/50-fty-alert-flexible-import-into-1.3.0.sh
@@ -61,6 +61,8 @@ for F in "$GENERATED_RULES_DIR"/*.rule ; do
     cp -f "$F" "$F.$BACKUPEXT" \
     || die "FAILED to copy '$F' into backup '$F.$BACKUPEXT'"
 
+    chmod --reference="$F" "$F.$BACKUPEXT"
+    chown --reference="$F" "$F.$BACKUPEXT"
 
     sed -r \
         -e 's/"action" *: *\[ *"([^"]*)" *\]/"action": \[\{"action": "\1"\}\]/' \

--- a/install.xml
+++ b/install.xml
@@ -18,4 +18,9 @@ Installation model
     <item path = "/usr/share/fty-alert-flexible/rules" name = "../src/selftest-ro/rules/load.rule" />
     <item path = "/usr/share/fty-alert-flexible/rules" name = "../src/selftest-ro/rules/ups.rule" />
     <item path = "/usr/share/fty-alert-flexible/rules" name = "../src/selftest-ro/rules/threshold.rule" />
+
+    <!-- Note: /bios/ pathname is correct here until replaced in favor of /fty/
+         EVERYWHERE in ecosystem at once; otherwise packaging is confused -->
+    <!-- Import of configuration data stored in IPM_Infra-1.2.0 format -->
+    <item path = "/usr/share/bios/setup" name = "50-fty-alert-flexible-import-into-1.3.0.sh" />
 </install>

--- a/packaging/debian/fty-alert-flexible.install
+++ b/packaging/debian/fty-alert-flexible.install
@@ -1,4 +1,6 @@
+### NOTE: This file was edited to add /usr/share/bios/setup/* scriptlet
 usr/bin/fty-alert-flexible
+usr/share/bios/setup/50-fty-alert-flexible-import-into-1.3.0.sh
 etc/fty-alert-flexible/fty-alert-flexible.cfg
 lib/systemd/system/fty-alert-flexible.service
 

--- a/packaging/redhat/fty-alert-flexible.spec
+++ b/packaging/redhat/fty-alert-flexible.spec
@@ -1,3 +1,4 @@
+### NOTE: This file was edited to add /usr/share/bios/setup/* scriptlet
 #
 #    fty-alert-flexible - agent for creating evaluating alerts
 #
@@ -119,6 +120,7 @@ find %{buildroot} -name '*.la' | xargs rm -f
 %doc README.md
 %{_bindir}/fty-alert-flexible
 %{_mandir}/man1/fty-alert-flexible*
+%{_datadir}/bios/setup/50-fty-alert-flexible-import-into-1.3.0.sh
 %config(noreplace) %{_sysconfdir}/fty-alert-flexible/fty-alert-flexible.cfg
 %{SYSTEMD_UNIT_DIR}/fty-alert-flexible.service
 %dir %{_sysconfdir}/fty-alert-flexible

--- a/src/Makemodule-local.am
+++ b/src/Makemodule-local.am
@@ -1,0 +1,6 @@
+# Install setup scriptlet into /usr/share/bios/setup
+setupscriptletdir = $(datadir)/bios/setup
+setupscriptlet_SCRIPTS = \
+    50-fty-alert-flexible-import-into-1.3.0.sh
+
+EXTRA_DIST += 50-fty-alert-flexible-import-into-1.3.0.sh


### PR DESCRIPTION
Solution: Introduce 50-fty-alert-flexible-import-into-1.3.0.sh ipc-meta-setup scriptlet