### PR TITLE
Report rules on logical assets, if available

### DIFF
--- a/src/flexible_alert.c
+++ b/src/flexible_alert.c
@@ -165,13 +165,16 @@ flexible_alert_send_alert (flexible_alert_t *self, rule_t *rule, const char *ass
     // topic
     char *topic = zsys_sprintf ("%s/%s@%s", rule_name (rule), severity, asset);
 
+    // Logical asset if specified
+    const char *la = rule_logical_asset (rule);
+
     // message
     zmsg_t *alert = fty_proto_encode_alert (
         NULL,
         time(NULL),
         ttl,
         rule_name (rule),
-        asset,
+        la ? la : asset,
         result == 0 ? "RESOLVED" : "ACTIVE",
         severity,
         message,

--- a/src/rule.c
+++ b/src/rule.c
@@ -267,6 +267,16 @@ rule_name (rule_t *self)
 
 
 //  --------------------------------------------------------------------------
+//  Get the logical asset
+
+const char *
+rule_logical_asset (rule_t *self)
+{
+    assert (self);
+    return self->logical_asset;
+}
+
+//  --------------------------------------------------------------------------
 //  Does rule contain this asset name?
 
 bool

--- a/src/rule.h
+++ b/src/rule.h
@@ -59,6 +59,10 @@ FTY_ALERT_FLEXIBLE_PRIVATE int
 FTY_ALERT_FLEXIBLE_PRIVATE const char *
     rule_name (rule_t *self);
 
+//  Get the logical asset
+FTY_ALERT_FLEXIBLE_PRIVATE const char *
+    rule_logical_asset (rule_t *self);
+
 //  Does rule contain this asset name?
 FTY_ALERT_FLEXIBLE_PRIVATE bool
     rule_asset_exists (rule_t *self, const char *asset);


### PR DESCRIPTION
We want the sensor alerts to trigger on their logical assets. For T&H
sensors, this just works thanks to fty-metric-compute, which provides
the averages for racks, rows, etc and fty-alert-engine triggers alerts
based on those averages. For GPI metrics, there is no such
transformation, so we need to do it in the alert actor.

Note that the solution is not elegant, as there can be multiple assets
per rule in theory and only a single logical asset name, but in
practice, the array has a single element (the array itself is kind of a
hack in first place). Another minor issue is that the alert subject
still lists the sensorgpio asset, instead of the logical asset.