### PR TITLE
Problem: Empty action sets are discarded

### DIFF
--- a/src/rule.cc
+++ b/src/rule.cc
@@ -643,11 +643,6 @@ static char * s_actions_to_json_array (zlist_t *actions)
     size_t jsonsize = 0;
     s_string_append (&json, &jsonsize, "[");
     while (item) {
-        // empty action
-        if (!item) {
-            log_debug("%s: action is empty", __func__);
-            continue;
-        }
         s_string_append (&json, &jsonsize, "{\"action\": ");
         const char *p = item;
         const char *colon = strchr (p, ':');

--- a/src/selftest-ro/rules/old.json
+++ b/src/selftest-ro/rules/old.json
@@ -7,6 +7,7 @@
 "models":[],
 "groups":[],
 "results": {
+"high_warning": {"action": []},
 "low_critical": {"action": [{"action": "SMS"}, {"action": "EMAIL"}]},
 "high_critical": {"action": [{"action": "EMAIL"}, {"action": "SMS"}]}},
 "evaluation":"\n         function main(load)\n             if load > 90 then\n                 return HIGH_CRITICAL, NAME .. ' is overloaded (' .. load .. '%);\n             end\n             if load > 70 then\n                 return HIGH_WARNING, NAME .. ' is overloaded (' .. load .. '%);\n             end\n             return OK, 'Load on ' .. NAME ..  ' is within limit (' .. load .. '%)';\n         end\n    "

--- a/src/selftest-ro/rules/test.json
+++ b/src/selftest-ro/rules/test.json
@@ -7,6 +7,7 @@
 "models":[],
 "groups":[],
 "results": {
+"high_warning": {"action": []},
 "low_critical": {"action": [{"action": "SMS"}, {"action": "EMAIL"}, {"action": "GPO_INTERACTION", "asset": "gpo-42", "mode": "close"}]},
 "high_critical": {"action": [{"action": "EMAIL"}, {"action": "SMS"}, {"action": "GPO_INTERACTION", "asset": "gpo-42", "mode": "open"}]}},
 "evaluation":"\n         function main(load)\n             if load > 90 then\n                 return HIGH_CRITICAL, NAME .. ' is overloaded (' .. load .. '%);\n             end\n             if load > 70 then\n                 return HIGH_WARNING, NAME .. ' is overloaded (' .. load .. '%);\n             end\n             return OK, 'Load on ' .. NAME ..  ' is within limit (' .. load .. '%)';\n         end\n    "

--- a/src/selftest-ro/rules/test.rule
+++ b/src/selftest-ro/rules/test.rule
@@ -15,7 +15,7 @@
         "low_critical": { "action" : [
             {"action": "SMS"},
             {"action": "EMAIL"},
-            {"asset": "gpo-42", "action": "GPO_INTERACTION", "mode": "close"}] }
+            {"action": "GPO_INTERACTION", "asset": "gpo-42", "mode": "close"}] }
     },
     "evaluation"    : "
          function main(load)


### PR DESCRIPTION
Solution: Handle empty action sets
This seems to be a regression WRT previous behavior.
The absence of the action array, when no action is set, results in UI not
displaying flexible rules in Settings->Alarms (for ATS/STS for example)

WARNING: fields order seems to matter (to be audited) since the following
seems to be discarded
{"asset": "gpo-42", "action": "GPO_INTERACTION", "mode": "close"}] }
while this one seems fine ("action" first)
{"action": "GPO_INTERACTION", "asset": "gpo-42", "mode": "close"}] }

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>