### PR TITLE
Incorrect comment leads to config not loaded

### DIFF
--- a/src/fty-alert-flexible.cfg.in
+++ b/src/fty-alert-flexible.cfg.in
@@ -8,7 +8,7 @@ server
 
 malamute
     endpoint = ipc://@/malamute                     # Malamute endpoint
-    //metrics_pattern = .*@gpiosensor-.*|.*@sts-.*    # METRICS consumer pattern
+    #metrics_pattern = .*@gpiosensor-.*|.*@sts-.*    # METRICS consumer pattern
     metrics_pattern = .*    # METRICS consumer pattern
     assets_pattern = gpiosensor-.*|sts-.*
 


### PR DESCRIPTION
Apr 12 12:59:49 validation-rc3 systemd[1]: Starting fty-alert-flexible service...
Apr 12 12:59:49 validation-rc3 systemd[1]: Started fty-alert-flexible service.
Apr 12 12:59:49 validation-rc3 snoopy[4539]: [uid:1000 sid:4539 tty:(none) cwd:/ filename:/usr/bin/fty-alert-flexible]: /usr/bin/fty-alert-flexible --rules /var/lib/fty/fty-alert-flexible/rules
Apr 12 12:59:52 validation-rc3 fty-alert-flexible[4539]: 19-04-12 12:59:49 E (zconfig): (11) '/' not valid at name start or end
Apr 12 12:59:52 validation-rc3 fty-alert-flexible[4539]: fty-alert-flexible [3070066688] -ERROR- main (src/fty_alert_flexible.cc:125) Failed to load config file /etc/fty-alert-flexible/fty-alert-flexible.cfg